### PR TITLE
removing _doc mapping type and replacing with default 

### DIFF
--- a/Adding Boolean Logic to Queries/debugging-bool-queries-with-named-queries.md
+++ b/Adding Boolean Logic to Queries/debugging-bool-queries-with-named-queries.md
@@ -1,7 +1,7 @@
 # Debugging `bool` queries with named queries
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
     "query": {
         "bool": {

--- a/Adding Boolean Logic to Queries/how-the-match-query-works.md
+++ b/Adding Boolean Logic to Queries/how-the-match-query-works.md
@@ -3,7 +3,7 @@
 ## The two queries below are equivalent
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match": {
@@ -14,7 +14,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {
@@ -38,7 +38,7 @@ GET /recipe/_doc/_search
 ## The two queries below are equivalent
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match": {
@@ -52,7 +52,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {

--- a/Adding Boolean Logic to Queries/querying-with-boolean-logic.md
+++ b/Adding Boolean Logic to Queries/querying-with-boolean-logic.md
@@ -3,7 +3,7 @@
 ## Adding query clauses to the `must` key
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {
@@ -29,7 +29,7 @@ GET /recipe/_doc/_search
 ## Moving the `range` query to the `filter` key
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {
@@ -57,7 +57,7 @@ GET /recipe/_doc/_search
 ## Adding a query clause to the `must_not` key
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {
@@ -92,7 +92,7 @@ GET /recipe/_doc/_search
 ## Adding a query clause to the `should` key
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {
@@ -134,7 +134,7 @@ GET /recipe/_doc/_search
 ## The behavior of `should` query clauses depends
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {
@@ -158,7 +158,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {

--- a/Aggregations/aggregating-nested-objects.md
+++ b/Aggregations/aggregating-nested-objects.md
@@ -1,7 +1,7 @@
 # Aggregating nested objects
 
 ```
-GET /department/_doc/_search
+GET /department/default/_search
 {
   "size": 0,
   "aggs": {
@@ -15,7 +15,7 @@ GET /department/_doc/_search
 ```
 
 ```
-GET /department/_doc/_search
+GET /department/default/_search
 {
   "size": 0,
   "aggs": {

--- a/Aggregations/defining-bucket-rules-with-filters.md
+++ b/Aggregations/defining-bucket-rules-with-filters.md
@@ -3,7 +3,7 @@
 ## Placing documents into buckets based on criteria
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "size": 0,
   "aggs": {
@@ -30,7 +30,7 @@ GET /recipe/_doc/_search
 ## Calculate average ratings for buckets
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "size": 0,
   "aggs": {

--- a/Aggregations/filtering-out-documents.md
+++ b/Aggregations/filtering-out-documents.md
@@ -3,7 +3,7 @@
 ## Filtering out documents with low `total_amount`
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -23,7 +23,7 @@ GET /order/_doc/_search
 ## Aggregating on the bucket of remaining documents
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {

--- a/Aggregations/global-aggregation.md
+++ b/Aggregations/global-aggregation.md
@@ -3,7 +3,7 @@
 ## Break out of the aggregation context
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "query": {
     "range": {
@@ -31,7 +31,7 @@ GET /order/_doc/_search
 ## Adding aggregation without global context
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "query": {
     "range": {

--- a/Aggregations/histograms.md
+++ b/Aggregations/histograms.md
@@ -3,7 +3,7 @@
 ## Distribution of `total_amount` with interval `25`
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -20,7 +20,7 @@ GET /order/_doc/_search
 ## Requiring minimum 1 document per bucket
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -38,7 +38,7 @@ GET /order/_doc/_search
 ## Specifying fixed bucket boundaries
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "query": {
@@ -67,7 +67,7 @@ GET /order/_doc/_search
 ## Aggregating by month with the `date_histogram` aggregation
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {

--- a/Aggregations/introduction-to-aggregations.md
+++ b/Aggregations/introduction-to-aggregations.md
@@ -54,5 +54,5 @@ PUT /order
 ## Populating the `order` index with test data
 
 ```
-curl -H "Content-Type: application/json" -XPOST 'http://localhost:9200/order/_doc/_bulk?pretty' --data-binary "@orders-bulk.json"
+curl -H "Content-Type: application/json" -XPOST 'http://localhost:9200/order/default/_bulk?pretty' --data-binary "@orders-bulk.json"
 ```

--- a/Aggregations/introduction-to-bucket-aggregations.md
+++ b/Aggregations/introduction-to-bucket-aggregations.md
@@ -3,7 +3,7 @@
 ## Creating a bucket for each `status` value
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -19,7 +19,7 @@ GET /order/_doc/_search
 ## Including `20` terms instead of the default `10`
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -36,7 +36,7 @@ GET /order/_doc/_search
 ## Aggregating documents with missing field (or `NULL`)
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -54,7 +54,7 @@ GET /order/_doc/_search
 ## Changing the minimum document count for a bucket to be created
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -73,7 +73,7 @@ GET /order/_doc/_search
 ## Ordering the buckets
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {

--- a/Aggregations/metric-aggregations.md
+++ b/Aggregations/metric-aggregations.md
@@ -3,7 +3,7 @@
 ## Calculating statistics with `sum`, `avg`, `min`, and `max` aggregations
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -34,7 +34,7 @@ GET /order/_doc/_search
 ## Retrieving the number of distinct values
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -50,7 +50,7 @@ GET /order/_doc/_search
 ## Retrieving the number of values
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -66,7 +66,7 @@ GET /order/_doc/_search
 ## Using `stats` aggregation for common statistics
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {

--- a/Aggregations/missing-field-values.md
+++ b/Aggregations/missing-field-values.md
@@ -3,14 +3,14 @@
 ## Adding test documents
 
 ```
-POST /order/_doc/1001
+POST /order/default/1001
 {
   "total_amount": 100
 }
 ```
 
 ```
-POST /order/_doc/1002
+POST /order/default/1002
 {
   "total_amount": 200,
   "status": null
@@ -20,7 +20,7 @@ POST /order/_doc/1002
 ## Aggregating documents with missing field value
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -36,7 +36,7 @@ GET /order/_doc/_search
 ## Combining `missing` aggregation with other aggregations
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -59,9 +59,9 @@ GET /order/_doc/_search
 ## Deleting test documents
 
 ```
-DELETE /order/_doc/1001
+DELETE /order/default/1001
 ```
 
 ```
-DELETE /order/_doc/1002
+DELETE /order/default/1002
 ```

--- a/Aggregations/nested-aggregations.md
+++ b/Aggregations/nested-aggregations.md
@@ -3,7 +3,7 @@
 ## Retrieving statistics for each status
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -26,7 +26,7 @@ GET /order/_doc/_search
 ## Narrowing down the aggregation context
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "query": {

--- a/Aggregations/range-aggregations.md
+++ b/Aggregations/range-aggregations.md
@@ -3,7 +3,7 @@
 ## `range` aggregation
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -31,7 +31,7 @@ GET /order/_doc/_search
 ## `date_range` aggregation
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -57,7 +57,7 @@ GET /order/_doc/_search
 ## Specifying the date format
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -84,7 +84,7 @@ GET /order/_doc/_search
 ## Enabling keys for the buckets
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -112,7 +112,7 @@ GET /order/_doc/_search
 ## Defining the bucket keys
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {
@@ -142,7 +142,7 @@ GET /order/_doc/_search
 ## Adding a sub-aggregation
 
 ```
-GET /order/_doc/_search
+GET /order/default/_search
 {
   "size": 0,
   "aggs": {

--- a/Analysis & Analyzers/using-analyzers-in-mappings.md
+++ b/Analysis & Analyzers/using-analyzers-in-mappings.md
@@ -3,7 +3,7 @@
 ## Using a custom analyzer in field mappings
 
 ```
-PUT /analyzers_test/_doc/_mapping
+PUT /analyzers_test/default/_mapping
 {
   "properties": {
     "description": {
@@ -21,7 +21,7 @@ PUT /analyzers_test/_doc/_mapping
 ## Adding a test document
 
 ```
-POST /analyzers_test/_doc/1
+POST /analyzers_test/default/1
 {
   "description": "drinking",
   "teaser": "drinking"
@@ -31,7 +31,7 @@ POST /analyzers_test/_doc/1
 ## Testing the mapping
 
 ```
-GET /analyzers_test/_doc/_search
+GET /analyzers_test/default/_search
 {
   "query": {
     "term": {
@@ -44,7 +44,7 @@ GET /analyzers_test/_doc/_search
 ```
 
 ```
-GET /analyzers_test/_doc/_search
+GET /analyzers_test/default/_search
 {
   "query": {
     "term": {

--- a/Controlling Query Results/filters.md
+++ b/Controlling Query Results/filters.md
@@ -3,7 +3,7 @@
 ## Adding a `filter` clause to the `bool` query
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "bool": {

--- a/Controlling Query Results/sorting-by-multi-value-fields.md
+++ b/Controlling Query Results/sorting-by-multi-value-fields.md
@@ -3,7 +3,7 @@
 ## Sorting by the average rating (descending)
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": "ratings",
   "query": {

--- a/Controlling Query Results/sorting-results.md
+++ b/Controlling Query Results/sorting-results.md
@@ -3,7 +3,7 @@
 ## Sorting by ascending order (implicitly)
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": false,
   "query": {
@@ -18,7 +18,7 @@ GET /recipe/_doc/_search
 ## Sorting by descending order
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": "created",
   "query": {
@@ -33,7 +33,7 @@ GET /recipe/_doc/_search
 ## Sorting by multiple fields
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": [ "preparation_time_minutes", "created" ],
   "query": {

--- a/Controlling Query Results/source-filtering.md
+++ b/Controlling Query Results/source-filtering.md
@@ -3,7 +3,7 @@
 ## Excluding the `_source` field altogether
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": false,
   "query": {
@@ -15,7 +15,7 @@ GET /recipe/_doc/_search
 ## Only returning the `created` field
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": "created",
   "query": {
@@ -27,7 +27,7 @@ GET /recipe/_doc/_search
 ## Only returning an object's key
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": "ingredients.name",
   "query": {
@@ -39,7 +39,7 @@ GET /recipe/_doc/_search
 ## Returning all of an object's keys
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": "ingredients.*",
   "query": {
@@ -51,7 +51,7 @@ GET /recipe/_doc/_search
 ## Returning the `ingredients` object with all keys, __and__ the `servings` field
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": [ "ingredients.*", "servings" ],
   "query": {
@@ -63,7 +63,7 @@ GET /recipe/_doc/_search
 ## Including all of the `ingredients` object's keys, except the `name` key
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": {
     "includes": "ingredients.*",

--- a/Controlling Query Results/specifying-an-offset.md
+++ b/Controlling Query Results/specifying-an-offset.md
@@ -3,7 +3,7 @@
 ## Specifying an offset with the `from` parameter
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": false,
   "size": 2,

--- a/Controlling Query Results/specifying-the-result-format.md
+++ b/Controlling Query Results/specifying-the-result-format.md
@@ -3,7 +3,7 @@
 ## Returning results as YAML
 
 ```
-GET /recipe/_doc/_search?format=yaml
+GET /recipe/default/_search?format=yaml
 {
     "query": {
       "match": { "title": "pasta" }
@@ -14,7 +14,7 @@ GET /recipe/_doc/_search?format=yaml
 ## Returning pretty JSON
 
 ```
-GET /recipe/_doc/_search?pretty
+GET /recipe/default/_search?pretty
 {
     "query": {
       "match": { "title": "pasta" }

--- a/Controlling Query Results/specifying-the-result-size.md
+++ b/Controlling Query Results/specifying-the-result-size.md
@@ -3,7 +3,7 @@
 ## Using a query parameter
 
 ```
-GET /recipe/_doc/_search?size=2
+GET /recipe/default/_search?size=2
 {
   "_source": false,
   "query": {
@@ -17,7 +17,7 @@ GET /recipe/_doc/_search?size=2
 ## Using a parameter within the request body
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "_source": false,
   "size": 2,

--- a/Full Text Queries/exercises.md
+++ b/Full Text Queries/exercises.md
@@ -1,7 +1,7 @@
 # Exercises
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match": {
@@ -12,7 +12,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match_phrase": {
@@ -23,7 +23,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match_phrase": {
@@ -34,7 +34,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "multi_match": {

--- a/Full Text Queries/flexible-matching-with-match-query.md
+++ b/Full Text Queries/flexible-matching-with-match-query.md
@@ -3,7 +3,7 @@
 ## Standard `match` query
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match": {
@@ -16,7 +16,7 @@ GET /recipe/_doc/_search
 ## Specifying a boolean operator
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match": {
@@ -30,7 +30,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match": {
@@ -44,7 +44,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match": {

--- a/Full Text Queries/introduction-to-full-text-queries.md
+++ b/Full Text Queries/introduction-to-full-text-queries.md
@@ -7,11 +7,11 @@ cd /path/to/data/file/directory
 ```
 
 ```shell
-curl -H "Content-Type: application/json" -XPOST 'http://localhost:9200/recipe/_doc/_bulk?pretty' --data-binary "@test-data.json"
+curl -H "Content-Type: application/json" -XPOST 'http://localhost:9200/recipe/default/_bulk?pretty' --data-binary "@test-data.json"
 ```
 
 ## Inspecting the mapping
 
 ```
-GET /recipe/_doc/_mapping
+GET /recipe/default/_mapping
 ```

--- a/Full Text Queries/matching-phrases.md
+++ b/Full Text Queries/matching-phrases.md
@@ -3,7 +3,7 @@
 ## The order of terms matters
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match_phrase": {
@@ -14,7 +14,7 @@ GET /recipe/_doc/_search
 ```
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "match_phrase": {

--- a/Full Text Queries/searching-multiple-fields.md
+++ b/Full Text Queries/searching-multiple-fields.md
@@ -1,7 +1,7 @@
 # Searching multiple fields
 
 ```
-GET /recipe/_doc/_search
+GET /recipe/default/_search
 {
   "query": {
     "multi_match": {

--- a/Improving Search Results/adding-synonyms.md
+++ b/Improving Search Results/adding-synonyms.md
@@ -88,7 +88,7 @@ POST /synonyms/_doc
 ## Searching the index for synonyms
 
 ```
-GET /synonyms/_doc/_search
+GET /synonyms/default/_search
 {
   "query": {
     "match": {
@@ -99,7 +99,7 @@ GET /synonyms/_doc/_search
 ```
 
 ```
-GET /synonyms/_doc/_search
+GET /synonyms/default/_search
 {
   "query": {
     "match": {

--- a/Improving Search Results/affecting-relevance-scoring-with-proximity.md
+++ b/Improving Search Results/affecting-relevance-scoring-with-proximity.md
@@ -3,7 +3,7 @@
 ## A simple `match` query within a `bool` query
 
 ```
-GET /proximity/_doc/_search
+GET /proximity/default/_search
 {
   "query": {
     "bool": {
@@ -24,7 +24,7 @@ GET /proximity/_doc/_search
 ## Boosting relevance based on proximity
 
 ```
-GET /proximity/_doc/_search
+GET /proximity/default/_search
 {
   "query": {
     "bool": {
@@ -54,7 +54,7 @@ GET /proximity/_doc/_search
 ## Adding the `slop` parameter
 
 ```
-GET /proximity/_doc/_search
+GET /proximity/default/_search
 {
   "query": {
     "bool": {

--- a/Improving Search Results/fuzzy-match-query.md
+++ b/Improving Search Results/fuzzy-match-query.md
@@ -3,7 +3,7 @@
 ## Searching with `fuzziness` set to `auto`
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "match": {
@@ -17,7 +17,7 @@ GET /product/_doc/_search
 ```
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "match": {
@@ -33,7 +33,7 @@ GET /product/_doc/_search
 ## Fuzziness is per term (and specifying an integer)
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "match": {
@@ -50,7 +50,7 @@ GET /product/_doc/_search
 ## Switching letters around with transpositions
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "match": {
@@ -66,7 +66,7 @@ GET /product/_doc/_search
 ## Disabling transpositions
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "match": {

--- a/Improving Search Results/fuzzy-query.md
+++ b/Improving Search Results/fuzzy-query.md
@@ -1,7 +1,7 @@
 # `fuzzy` query
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "fuzzy": {
@@ -15,7 +15,7 @@ GET /product/_doc/_search
 ```
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "fuzzy": {

--- a/Improving Search Results/highlighting-matches-in-fields.md
+++ b/Improving Search Results/highlighting-matches-in-fields.md
@@ -3,7 +3,7 @@
 ## Adding a test document
 
 ```
-POST /highlighting/_doc/1
+POST /highlighting/default/1
 {
   "description": "Let me tell you a story about Elasticsearch. It's a full-text search engine that is built on Apache Lucene. It's really easy to use, but also packs lots of advanced features that you can use to tweak its searching capabilities. Lots of well-known and established companies use Elasticsearch, and so should you!"
 }
@@ -12,7 +12,7 @@ POST /highlighting/_doc/1
 ## Highlighting matches within the `description` field
 
 ```
-GET /highlighting/_doc/_search
+GET /highlighting/default/_search
 {
   "_source": false,
   "query": {
@@ -29,7 +29,7 @@ GET /highlighting/_doc/_search
 ## Specifying a custom tag
 
 ```
-GET /highlighting/_doc/_search
+GET /highlighting/default/_search
 {
   "_source": false,
   "query": {

--- a/Improving Search Results/proximity-searches.md
+++ b/Improving Search Results/proximity-searches.md
@@ -3,35 +3,35 @@
 ## Adding test documents
 
 ```
-PUT /proximity/_doc/1
+PUT /proximity/default/1
 {
   "title": "Spicy Sauce"
 }
 ```
 
 ```
-PUT /proximity/_doc/2
+PUT /proximity/default/2
 {
   "title": "Spicy Tomato Sauce"
 }
 ```
 
 ```
-PUT /proximity/_doc/3
+PUT /proximity/default/3
 {
   "title": "Spicy Tomato and Garlic Sauce"
 }
 ```
 
 ```
-PUT /proximity/_doc/4
+PUT /proximity/default/4
 {
   "title": "Tomato Sauce (spicy)"
 }
 ```
 
 ```
-PUT /proximity/_doc/5
+PUT /proximity/default/5
 {
   "title": "Spicy and very delicious Tomato Sauce"
 }
@@ -40,7 +40,7 @@ PUT /proximity/_doc/5
 ## Adding the `slop` parameter to a `match_phrase` query
 
 ```
-GET /proximity/_doc/_search
+GET /proximity/default/_search
 {
   "query": {
     "match_phrase": {
@@ -54,7 +54,7 @@ GET /proximity/_doc/_search
 ```
 
 ```
-GET /proximity/_doc/_search
+GET /proximity/default/_search
 {
   "query": {
     "match_phrase": {

--- a/Improving Search Results/stemming.md
+++ b/Improving Search Results/stemming.md
@@ -48,7 +48,7 @@ PUT /stemming_test
 ## Adding a test document
 
 ```
-POST /stemming_test/_doc/1
+POST /stemming_test/default/1
 {
   "description": "I love working for my firm!"
 }
@@ -57,7 +57,7 @@ POST /stemming_test/_doc/1
 ## Matching the document with the base word (`work`)
 
 ```
-GET /stemming_test/_doc/_search
+GET /stemming_test/default/_search
 {
   "query": {
     "match": {
@@ -70,7 +70,7 @@ GET /stemming_test/_doc/_search
 ## The query is stemmed, so the document still matches
 
 ```
-GET /stemming_test/_doc/_search
+GET /stemming_test/default/_search
 {
   "query": {
     "match": {
@@ -83,7 +83,7 @@ GET /stemming_test/_doc/_search
 ## Synonyms and stemmed words are still highlighted
 
 ```
-GET /stemming_test/_doc/_search
+GET /stemming_test/default/_search
 {
   "query": {
     "match": {

--- a/Introduction to Searching/debugging-unexpected-query-results.md
+++ b/Introduction to Searching/debugging-unexpected-query-results.md
@@ -1,7 +1,7 @@
 # Debugging unexpected query results
 
 ```
-GET /product/_doc/1/_explain
+GET /product/default/1/_explain
 {
   "query": {
     "term": {

--- a/Introduction to Searching/full-text-queries-vs-term-level-queries.md
+++ b/Introduction to Searching/full-text-queries-vs-term-level-queries.md
@@ -3,7 +3,7 @@
 ## Term level queries are not analyzed
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "term": {
@@ -14,7 +14,7 @@ GET /product/_doc/_search
 ```
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "term": {
@@ -27,7 +27,7 @@ GET /product/_doc/_search
 ## Full-text queries are analyzed
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "match": {

--- a/Introduction to Searching/introducing-the-query-dsl.md
+++ b/Introduction to Searching/introducing-the-query-dsl.md
@@ -3,7 +3,7 @@
 ## Matching all documents
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "match_all": {}

--- a/Introduction to Searching/searching-with-the-request-uri.md
+++ b/Introduction to Searching/searching-with-the-request-uri.md
@@ -3,23 +3,23 @@
 ## Matching all documents
 
 ```
-GET /product/_doc/_search?q=*
+GET /product/default/_search?q=*
 ```
 
 ## Matching documents containing the term `Lobster`
 
 ```
-GET /product/_doc/_search?q=name:Lobster
+GET /product/default/_search?q=name:Lobster
 ```
 
 ## Matching documents containing the tag `Meat`
 
 ```
-GET /product/_doc/_search?q=tags:Meat
+GET /product/default/_search?q=tags:Meat
 ```
 
 ## Matching documents containing the tag `Meat` _and_ name `Tuna`
 
 ```
-GET /product/_doc/_search?q=tags:Meat AND name:Tuna
+GET /product/default/_search?q=tags:Meat AND name:Tuna
 ```

--- a/Introduction to Searching/understanding-relevance-scores.md
+++ b/Introduction to Searching/understanding-relevance-scores.md
@@ -1,7 +1,7 @@
 # Understanding relevance scores
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "explain": true,
   "query": {

--- a/Joining Queries/adding-documents.md
+++ b/Joining Queries/adding-documents.md
@@ -3,7 +3,7 @@
 ## Adding departments
 
 ```
-PUT /department/_doc/1
+PUT /department/default/1
 {
   "name": "Development",
   "join_field": "department"
@@ -11,7 +11,7 @@ PUT /department/_doc/1
 ```
 
 ```
-PUT /department/_doc/2
+PUT /department/default/2
 {
   "name": "Marketing",
   "join_field": "department"
@@ -21,7 +21,7 @@ PUT /department/_doc/2
 ## Adding employees for departments
 
 ```
-PUT /department/_doc/3?routing=1
+PUT /department/default/3?routing=1
 {
   "name": "Bo Andersen",
   "age": 28,
@@ -34,7 +34,7 @@ PUT /department/_doc/3?routing=1
 ```
 
 ```
-PUT /department/_doc/4?routing=2
+PUT /department/default/4?routing=2
 {
   "name": "John Doe",
   "age": 44,
@@ -47,7 +47,7 @@ PUT /department/_doc/4?routing=2
 ```
 
 ```
-PUT /department/_doc/5?routing=1
+PUT /department/default/5?routing=1
 {
   "name": "James Evans",
   "age": 32,
@@ -60,7 +60,7 @@ PUT /department/_doc/5?routing=1
 ```
 
 ```
-PUT /department/_doc/6?routing=1
+PUT /department/default/6?routing=1
 {
   "name": "Daniel Harris",
   "age": 52,
@@ -73,7 +73,7 @@ PUT /department/_doc/6?routing=1
 ```
 
 ```
-PUT /department/_doc/7?routing=2
+PUT /department/default/7?routing=2
 {
   "name": "Jane Park",
   "age": 23,
@@ -86,7 +86,7 @@ PUT /department/_doc/7?routing=2
 ```
 
 ```
-PUT /department/_doc/8?routing=1
+PUT /department/default/8?routing=1
 {
   "name": "Christina Parker",
   "age": 29,

--- a/Joining Queries/multi-level-relations.md
+++ b/Joining Queries/multi-level-relations.md
@@ -24,7 +24,7 @@ PUT /company
 ## Adding a company
 
 ```
-PUT /company/_doc/1
+PUT /company/default/1
 {
   "name": "My Company Inc.",
   "join_field": "company"
@@ -34,7 +34,7 @@ PUT /company/_doc/1
 ## Adding a department
 
 ```
-PUT /company/_doc/2?routing=1
+PUT /company/default/2?routing=1
 {
   "name": "Development",
   "join_field": {
@@ -47,7 +47,7 @@ PUT /company/_doc/2?routing=1
 ## Adding an employee
 
 ```
-PUT /company/_doc/3?routing=1
+PUT /company/default/3?routing=1
 {
   "name": "Bo Andersen",
   "join_field": {
@@ -59,7 +59,7 @@ PUT /company/_doc/3?routing=1
 
 ## Adding some more test data
 ```
-PUT /company/_doc/4
+PUT /company/default/4
 {
   "name": "Another Company, Inc.",
   "join_field": "company"
@@ -67,7 +67,7 @@ PUT /company/_doc/4
 ```
 
 ```
-PUT /company/_doc/5?routing=4
+PUT /company/default/5?routing=4
 {
   "name": "Marketing",
   "join_field": {
@@ -78,7 +78,7 @@ PUT /company/_doc/5?routing=4
 ```
 
 ```
-PUT /company/_doc/6?routing=4
+PUT /company/default/6?routing=4
 {
   "name": "John Doe",
   "join_field": {

--- a/Joining Queries/querying-nested-objects.md
+++ b/Joining Queries/querying-nested-objects.md
@@ -23,7 +23,7 @@ PUT /department
 ## Adding test documents
 
 ```
-POST /department/_doc/1
+POST /department/default/1
 {
   "name": "Development",
   "employees": [
@@ -62,7 +62,7 @@ POST /department/_doc/1
 ```
 
 ```
-POST /department/_doc/2
+POST /department/default/2
 {
   "name": "HR & Marketing",
   "employees": [

--- a/Joining Queries/terms-lookup-mechanism.md
+++ b/Joining Queries/terms-lookup-mechanism.md
@@ -3,7 +3,7 @@
 ## Adding test data
 
 ```
-PUT /users/_doc/1
+PUT /users/default/1
 {
   "name": "John Roberts",
   "following" : [2, 3]
@@ -11,7 +11,7 @@ PUT /users/_doc/1
 ```
 
 ```
-PUT /users/_doc/2
+PUT /users/default/2
 {
   "name": "Elizabeth Ross",
   "following" : []
@@ -19,7 +19,7 @@ PUT /users/_doc/2
 ```
 
 ```
-PUT /users/_doc/3
+PUT /users/default/3
 {
   "name": "Jeremy Brooks",
   "following" : [1, 2]
@@ -27,7 +27,7 @@ PUT /users/_doc/3
 ```
 
 ```
-PUT /users/_doc/4
+PUT /users/default/4
 {
   "name": "Diana Moore",
   "following" : [3, 1]
@@ -35,7 +35,7 @@ PUT /users/_doc/4
 ```
 
 ```
-PUT /stories/_doc/1
+PUT /stories/default/1
 {
   "user": 3,
   "content": "Wow look, a penguin!"
@@ -43,7 +43,7 @@ PUT /stories/_doc/1
 ```
 
 ```
-PUT /stories/_doc/2
+PUT /stories/default/2
 {
   "user": 1,
   "content": "Just another day at the office... #coffee"
@@ -51,7 +51,7 @@ PUT /stories/_doc/2
 ```
 
 ```
-PUT /stories/_doc/3
+PUT /stories/default/3
 {
   "user": 1,
   "content": "Making search great again! #elasticsearch #elk"
@@ -59,7 +59,7 @@ PUT /stories/_doc/3
 ```
 
 ```
-PUT /stories/_doc/4
+PUT /stories/default/4
 {
   "user": 4,
   "content": "Had a blast today! #rollercoaster #amusementpark"
@@ -67,7 +67,7 @@ PUT /stories/_doc/4
 ```
 
 ```
-PUT /stories/_doc/5
+PUT /stories/default/5
 {
   "user": 4,
   "content": "Yay, I just got hired as an Elasticsearch consultant - so excited!"
@@ -75,7 +75,7 @@ PUT /stories/_doc/5
 ```
 
 ```
-PUT /stories/_doc/6
+PUT /stories/default/6
 {
   "user": 2,
   "content": "Chilling at the beach @ Greece #vacation #goodtimes"

--- a/Managing Documents/adding-documents.md
+++ b/Managing Documents/adding-documents.md
@@ -16,7 +16,7 @@ POST /product/_doc
 ## Adding document by ID:
 
 ```
-PUT /product/_doc/1
+PUT /product/default/1
 {
   "name": "Complete Guide to Elasticsearch",
   "instructor": {

--- a/Managing Documents/batch-processing.md
+++ b/Managing Documents/batch-processing.md
@@ -3,7 +3,7 @@
 ## Adding documents
 
 ```
-POST /product/_doc/_bulk
+POST /product/default/_bulk
 { "index": { "_id": "100" } }
 { "price": 100 }
 { "index": { "_id": "101" } }
@@ -13,7 +13,7 @@ POST /product/_doc/_bulk
 ## Updating and deleting documents
 
 ```
-POST /product/_doc/_bulk
+POST /product/default/_bulk
 { "update": { "_id": "100" } }
 { "doc": { "price": 1000 } }
 { "delete": { "_id": "101" } }
@@ -22,9 +22,9 @@ POST /product/_doc/_bulk
 ## Retrieving affected documents
 
 ```
-GET /product/_doc/100
+GET /product/default/100
 ```
 
 ```
-GET /product/_doc/101
+GET /product/default/101
 ```

--- a/Managing Documents/deleting-documents.md
+++ b/Managing Documents/deleting-documents.md
@@ -3,7 +3,7 @@
 ## Deleting document by ID
 
 ```
-DELETE /product/_doc/1
+DELETE /product/default/1
 ```
 
 ## Adding test documents

--- a/Managing Documents/importing-test-data.md
+++ b/Managing Documents/importing-test-data.md
@@ -9,5 +9,5 @@ cd /path/to/data/file/directory
 ## Importing test data with cURL
 
 ```
-curl -H "Content-Type: application/json" -XPOST 'http://localhost:9200/product/_doc/_bulk?pretty' --data-binary "@products-bulk.json"
+curl -H "Content-Type: application/json" -XPOST 'http://localhost:9200/product/default/_bulk?pretty' --data-binary "@products-bulk.json"
 ```

--- a/Managing Documents/replacing-documents.md
+++ b/Managing Documents/replacing-documents.md
@@ -3,7 +3,7 @@
 ## Replacing an existing document
 
 ```
-PUT /product/_doc/1
+PUT /product/default/1
 {
   "name": "Complete Guide to Elasticsearch",
   "price": 195,
@@ -17,5 +17,5 @@ PUT /product/_doc/1
 ## Retrieving the replaced document
 
 ```
-GET /product/_doc/1
+GET /product/default/1
 ```

--- a/Managing Documents/retrieving-documents-by-id.md
+++ b/Managing Documents/retrieving-documents-by-id.md
@@ -1,5 +1,5 @@
 # Retrieving documents by ID
 
 ```
-GET /product/_doc/1
+GET /product/default/1
 ```

--- a/Managing Documents/scripted-updates.md
+++ b/Managing Documents/scripted-updates.md
@@ -3,7 +3,7 @@
 ## Updating a document with a script
 
 ```
-POST /product/_doc/1/_update
+POST /product/default/1/_update
 {
   "script": "ctx._source.price += 10"
 }
@@ -12,5 +12,5 @@ POST /product/_doc/1/_update
 ## Retrieving the updated document
 
 ```
-GET /product/_doc/1
+GET /product/default/1
 ```

--- a/Managing Documents/updating-documents.md
+++ b/Managing Documents/updating-documents.md
@@ -3,7 +3,7 @@
 ## Updating `price` field and adding `tags` field
 
 ```
-POST /product/_doc/1/_update
+POST /product/default/1/_update
 {
   "doc": { "price": 95, "tags": [ "Elasticsearch" ] }
 }
@@ -12,5 +12,5 @@ POST /product/_doc/1/_update
 ## Retrieving the updated document
 
 ```
-GET /product/_doc/1
+GET /product/default/1
 ```

--- a/Managing Documents/upserts.md
+++ b/Managing Documents/upserts.md
@@ -3,13 +3,13 @@
 ## Deleting the existing document
 
 ```
-DELETE /product/_doc/1
+DELETE /product/default/1
 ```
 
 ## Inserting or updating a document (upsert)
 
 ```
-POST /product/_doc/1/_update
+POST /product/default/1/_update
 {
     "script" : "ctx._source.price += 5",
     "upsert" : {
@@ -21,5 +21,5 @@ POST /product/_doc/1/_update
 ## Retrieving the document
 
 ```
-GET /product/_doc/1
+GET /product/default/1
 ```

--- a/Mapping/adding-mappings-to-existing-indices.md
+++ b/Mapping/adding-mappings-to-existing-indices.md
@@ -3,7 +3,7 @@
 ## Adding mapping for `discount` field
 
 ```
-PUT /product/_doc/_mapping
+PUT /product/default/_mapping
 {
   "properties": {
     "discount": {
@@ -16,5 +16,5 @@ PUT /product/_doc/_mapping
 ## Retrieving mapping
 
 ```
-GET /product/_doc/_mapping
+GET /product/default/_mapping
 ```

--- a/Mapping/adding-multi-fields-mappings.md
+++ b/Mapping/adding-multi-fields-mappings.md
@@ -3,7 +3,7 @@
 ## Adding mappings
 
 ```
-PUT /product/_doc/_mapping
+PUT /product/default/_mapping
 {
   "properties": {
     "description": {
@@ -32,5 +32,5 @@ PUT /product/_doc/_mapping
 ## Retrieving mapping
 
 ```
-GET /product/_doc/_mapping
+GET /product/default/_mapping
 ```

--- a/Mapping/defining-custom-date-formats.md
+++ b/Mapping/defining-custom-date-formats.md
@@ -3,7 +3,7 @@
 ## Date mapping with `year` format
 
 ```
-PUT /product/_doc/_mapping
+PUT /product/default/_mapping
 {
   "properties": {
     "created": {
@@ -17,7 +17,7 @@ PUT /product/_doc/_mapping
 ## Date mapping with `strict_year` format
 
 ```
-PUT /product/_doc/_mapping
+PUT /product/default/_mapping
 {
   "properties": {
     "created": {
@@ -31,7 +31,7 @@ PUT /product/_doc/_mapping
 ## Date mapping with explicit default format
 
 ```
-PUT /product/_doc/_mapping
+PUT /product/default/_mapping
 {
   "properties": {
     "created": {
@@ -45,7 +45,7 @@ PUT /product/_doc/_mapping
 ## Date mapping with date and optional time
 
 ```
-PUT /product/_doc/_mapping
+PUT /product/default/_mapping
 {
   "properties": {
     "created": {

--- a/Mapping/dynamic-mapping.md
+++ b/Mapping/dynamic-mapping.md
@@ -3,5 +3,5 @@
 ## Retrieving mapping
 
 ```
-GET /product/_doc/_mapping
+GET /product/default/_mapping
 ```

--- a/Mapping/picking-up-new-fields-without-dynamic-mapping.md
+++ b/Mapping/picking-up-new-fields-without-dynamic-mapping.md
@@ -3,7 +3,7 @@
 ## Adding test document
 
 ```
-POST /product/_doc/2000
+POST /product/default/2000
 {
   "description": "Test",
   "discount": 20
@@ -13,7 +13,7 @@ POST /product/_doc/2000
 ## Adding mapping for `discount` field
 
 ```
-PUT /product/_doc/_mapping
+PUT /product/default/_mapping
 {
   "properties": {
     "discount": {
@@ -26,7 +26,7 @@ PUT /product/_doc/_mapping
 ## Querying the `description` field
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "match": {
@@ -39,7 +39,7 @@ GET /product/_doc/_search
 ## Querying the `discount` field
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "term": {
@@ -58,5 +58,5 @@ POST /product/_update_by_query?conflicts=proceed
 ## Deleting the test document
 
 ```
-DELETE /product/_doc/2000
+DELETE /product/default/2000
 ```

--- a/Term Level Queries/exercises.md
+++ b/Term Level Queries/exercises.md
@@ -3,7 +3,7 @@
 ## Matching documents with a `sold` field of less than `10`
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -18,7 +18,7 @@ GET /product/_doc/_search
 ## Matching documents with a `sold` field between `10` (inclusive) and `30` (exclusive)
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -34,7 +34,7 @@ GET /product/_doc/_search
 ## Matching documents containing the tag `Meat`
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "term": {
@@ -47,7 +47,7 @@ GET /product/_doc/_search
 ## Matching documents containing `Tomato` or `Paste` within the `name` field
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "terms": {
@@ -60,7 +60,7 @@ GET /product/_doc/_search
 ## Matching documents containing `past` followed by an optional character, for the `name` field
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "wildcard": {
@@ -73,7 +73,7 @@ GET /product/_doc/_search
 ## Matching documents containing a number within the `name` field
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "regexp": {

--- a/Term Level Queries/matching-based-on-prefixes.md
+++ b/Term Level Queries/matching-based-on-prefixes.md
@@ -3,7 +3,7 @@
 ## Matching documents containing a tag beginning with `Vege`
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "prefix": {

--- a/Term Level Queries/matching-documents-with-non-null-values.md
+++ b/Term Level Queries/matching-documents-with-non-null-values.md
@@ -1,7 +1,7 @@
 # Matching documents with non-null values
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "exists": {

--- a/Term Level Queries/matching-documents-with-range-values.md
+++ b/Term Level Queries/matching-documents-with-range-values.md
@@ -3,7 +3,7 @@
 ## Matching documents with an `in_stock` field of between `1` and `5`, both included
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -19,7 +19,7 @@ GET /product/_doc/_search
 ## Matching documents with a date range
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -35,7 +35,7 @@ GET /product/_doc/_search
 ## Matching documents with a date range and custom date format
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {

--- a/Term Level Queries/retrieving-documents-based-on-ids.md
+++ b/Term Level Queries/retrieving-documents-based-on-ids.md
@@ -1,7 +1,7 @@
 # Retrieving documents based on IDs
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "ids": {

--- a/Term Level Queries/searching-for-a-term.md
+++ b/Term Level Queries/searching-for-a-term.md
@@ -3,7 +3,7 @@
 ## Matching documents with a value of `true` for the `is_active` field
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "term": {
@@ -14,7 +14,7 @@ GET /product/_doc/_search
 ```
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "term": {

--- a/Term Level Queries/searching-for-multiple-terms.md
+++ b/Term Level Queries/searching-for-multiple-terms.md
@@ -1,7 +1,7 @@
 # Searching for multiple terms
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "terms": {

--- a/Term Level Queries/searching-with-regular-expressions.md
+++ b/Term Level Queries/searching-with-regular-expressions.md
@@ -1,7 +1,7 @@
 # Searching with regular expressions
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "regexp": {

--- a/Term Level Queries/searching-with-wildcards.md
+++ b/Term Level Queries/searching-with-wildcards.md
@@ -3,7 +3,7 @@
 ## Adding an asterisk for any characters (zero or more)
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "wildcard": {
@@ -16,7 +16,7 @@ GET /product/_doc/_search
 ## Adding a question mark for any single character
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "wildcard": {
@@ -27,7 +27,7 @@ GET /product/_doc/_search
 ```
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "wildcard": {

--- a/Term Level Queries/working-with-relative-dates.md
+++ b/Term Level Queries/working-with-relative-dates.md
@@ -3,7 +3,7 @@
 ## Subtracting one year from `2010/01/01`
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -18,7 +18,7 @@ GET /product/_doc/_search
 ## Subtracting one year and one day from `2010/01/01`
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -33,7 +33,7 @@ GET /product/_doc/_search
 ## Subtracting one year from `2010/01/01` and rounding by month
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -48,7 +48,7 @@ GET /product/_doc/_search
 ## Rounding by month _before_ subtracting one year from `2010/01/01`
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -63,7 +63,7 @@ GET /product/_doc/_search
 ## Rounding by month _before_ subtracting one year from the current date
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {
@@ -78,7 +78,7 @@ GET /product/_doc/_search
 ## Matching documents with a `created` field containing the current date or later
 
 ```
-GET /product/_doc/_search
+GET /product/default/_search
 {
   "query": {
     "range": {


### PR DESCRIPTION
Multiple Mapping types are no longer supported from version ES 6.00+ and will be removed completely in ES 7. The default mapping type is a placeholder.

https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html