### PR TITLE
Update id in terms-lookup-mechanism to text field

### DIFF
--- a/Joining Queries/terms-lookup-mechanism.md
+++ b/Joining Queries/terms-lookup-mechanism.md
@@ -91,7 +91,7 @@ GET /stories/_search
     "terms": {
       "user": {
         "index": "users",
-        "id": 1,
+        "id": "1",
         "path": "following"
       }
     }


### PR DESCRIPTION
On elastic v 7.8.0 the current code gives
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "x_content_parse_exception",
        "reason" : "[6:15] [terms_lookup] id doesn't support values of type: VALUE_NUMBER"
      }
    ],
    "type" : "x_content_parse_exception",
    "reason" : "[6:15] [terms_lookup] id doesn't support values of type: VALUE_NUMBER"
  },
  "status" : 400
}
```
This can be solved with the proposed change.