### PR TITLE
Don't use non-existent keyword field.

### DIFF
--- a/Aggregations/introduction-to-bucket-aggregations.md
+++ b/Aggregations/introduction-to-bucket-aggregations.md
@@ -9,7 +9,7 @@ GET /order/_search
   "aggs": {
     "status_terms": {
       "terms": {
-        "field": "status.keyword"
+        "field": "status"
       }
     }
   }
@@ -25,7 +25,7 @@ GET /order/_search
   "aggs": {
     "status_terms": {
       "terms": {
-        "field": "status.keyword",
+        "field": "status",
         "size": 20
       }
     }
@@ -42,7 +42,7 @@ GET /order/_search
   "aggs": {
     "status_terms": {
       "terms": {
-        "field": "status.keyword",
+        "field": "status",
         "size": 20,
         "missing": "N/A"
       }
@@ -60,7 +60,7 @@ GET /order/_search
   "aggs": {
     "status_terms": {
       "terms": {
-        "field": "status.keyword",
+        "field": "status",
         "size": 20,
         "missing": "N/A",
         "min_doc_count": 0
@@ -79,7 +79,7 @@ GET /order/_search
   "aggs": {
     "status_terms": {
       "terms": {
-        "field": "status.keyword",
+        "field": "status",
         "size": 20,
         "missing": "N/A",
         "min_doc_count": 0,


### PR DESCRIPTION
With the type of `status` defined as `keyword` in https://github.com/codingexplained/complete-guide-to-elasticsearch/blame/master/Aggregations/introduction-to-aggregations.md#L31, the field `status.keyword` is not defined and the queries yield empty buckets. 

The proposed changes use the keyword field as intended. Alternatively the mapping could be adjusted. The associated lecture is contains the same error.