### PR TITLE
Fix `products` index name

### DIFF
--- a/Improving Search Results/fuzzy-match-query.md
+++ b/Improving Search Results/fuzzy-match-query.md
@@ -3,7 +3,7 @@
 ## Searching with `fuzziness` set to `auto`
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "match": {
@@ -17,7 +17,7 @@ GET /product/_search
 ```
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "match": {
@@ -33,7 +33,7 @@ GET /product/_search
 ## Fuzziness is per term (and specifying an integer)
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "match": {
@@ -50,7 +50,7 @@ GET /product/_search
 ## Switching letters around with transpositions
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "match": {
@@ -66,7 +66,7 @@ GET /product/_search
 ## Disabling transpositions
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "match": {

--- a/Improving Search Results/fuzzy-query.md
+++ b/Improving Search Results/fuzzy-query.md
@@ -1,7 +1,7 @@
 # `fuzzy` query
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "fuzzy": {
@@ -15,7 +15,7 @@ GET /product/_search
 ```
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "fuzzy": {

--- a/Introduction to Searching/debugging-unexpected-query-results.md
+++ b/Introduction to Searching/debugging-unexpected-query-results.md
@@ -1,7 +1,7 @@
 # Debugging unexpected query results
 
 ```
-GET /product/_doc/1/_explain
+GET /products/_doc/1/_explain
 {
   "query": {
     "term": {

--- a/Introduction to Searching/full-text-queries-vs-term-level-queries.md
+++ b/Introduction to Searching/full-text-queries-vs-term-level-queries.md
@@ -3,7 +3,7 @@
 ## Term level queries are not analyzed
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "term": {
@@ -14,7 +14,7 @@ GET /product/_search
 ```
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "term": {
@@ -27,7 +27,7 @@ GET /product/_search
 ## Full-text queries are analyzed
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "match": {

--- a/Introduction to Searching/introducing-the-query-dsl.md
+++ b/Introduction to Searching/introducing-the-query-dsl.md
@@ -3,7 +3,7 @@
 ## Matching all documents
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "match_all": {}

--- a/Introduction to Searching/searching-with-the-request-uri.md
+++ b/Introduction to Searching/searching-with-the-request-uri.md
@@ -3,23 +3,23 @@
 ## Matching all documents
 
 ```
-GET /product/_search?q=*
+GET /products/_search?q=*
 ```
 
 ## Matching documents containing the term `Lobster`
 
 ```
-GET /product/_search?q=name:Lobster
+GET /products/_search?q=name:Lobster
 ```
 
 ## Matching documents containing the tag `Meat`
 
 ```
-GET /product/_search?q=tags:Meat
+GET /products/_search?q=tags:Meat
 ```
 
 ## Matching documents containing the tag `Meat` _and_ name `Tuna`
 
 ```
-GET /product/_search?q=tags:Meat AND name:Tuna
+GET /products/_search?q=tags:Meat AND name:Tuna
 ```

--- a/Introduction to Searching/understanding-relevance-scores.md
+++ b/Introduction to Searching/understanding-relevance-scores.md
@@ -1,7 +1,7 @@
 # Understanding relevance scores
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "explain": true,
   "query": {

--- a/Term Level Queries/exercises.md
+++ b/Term Level Queries/exercises.md
@@ -3,7 +3,7 @@
 ## Matching documents with a `sold` field of less than `10`
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -18,7 +18,7 @@ GET /product/_search
 ## Matching documents with a `sold` field between `10` (inclusive) and `30` (exclusive)
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -34,7 +34,7 @@ GET /product/_search
 ## Matching documents containing the tag `Meat`
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "term": {
@@ -47,7 +47,7 @@ GET /product/_search
 ## Matching documents containing `Tomato` or `Paste` within the `name` field
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "terms": {
@@ -60,7 +60,7 @@ GET /product/_search
 ## Matching documents containing `past` followed by an optional character, for the `name` field
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "wildcard": {
@@ -73,7 +73,7 @@ GET /product/_search
 ## Matching documents containing a number within the `name` field
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "regexp": {

--- a/Term Level Queries/matching-based-on-prefixes.md
+++ b/Term Level Queries/matching-based-on-prefixes.md
@@ -3,7 +3,7 @@
 ## Matching documents containing a tag beginning with `Vege`
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "prefix": {

--- a/Term Level Queries/matching-documents-with-non-null-values.md
+++ b/Term Level Queries/matching-documents-with-non-null-values.md
@@ -1,7 +1,7 @@
 # Matching documents with non-null values
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "exists": {

--- a/Term Level Queries/matching-documents-with-range-values.md
+++ b/Term Level Queries/matching-documents-with-range-values.md
@@ -3,7 +3,7 @@
 ## Matching documents with an `in_stock` field of between `1` and `5`, both included
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -19,7 +19,7 @@ GET /product/_search
 ## Matching documents with a date range
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -35,7 +35,7 @@ GET /product/_search
 ## Matching documents with a date range and custom date format
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {

--- a/Term Level Queries/retrieving-documents-based-on-ids.md
+++ b/Term Level Queries/retrieving-documents-based-on-ids.md
@@ -1,7 +1,7 @@
 # Retrieving documents based on IDs
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "ids": {

--- a/Term Level Queries/searching-for-a-term.md
+++ b/Term Level Queries/searching-for-a-term.md
@@ -3,7 +3,7 @@
 ## Matching documents with a value of `true` for the `is_active` field
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "term": {
@@ -14,7 +14,7 @@ GET /product/_search
 ```
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "term": {

--- a/Term Level Queries/searching-for-multiple-terms.md
+++ b/Term Level Queries/searching-for-multiple-terms.md
@@ -1,7 +1,7 @@
 # Searching for multiple terms
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "terms": {

--- a/Term Level Queries/searching-with-regular-expressions.md
+++ b/Term Level Queries/searching-with-regular-expressions.md
@@ -1,7 +1,7 @@
 # Searching with regular expressions
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "regexp": {

--- a/Term Level Queries/searching-with-wildcards.md
+++ b/Term Level Queries/searching-with-wildcards.md
@@ -3,7 +3,7 @@
 ## Adding an asterisk for any characters (zero or more)
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "wildcard": {
@@ -16,7 +16,7 @@ GET /product/_search
 ## Adding a question mark for any single character
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "wildcard": {
@@ -27,7 +27,7 @@ GET /product/_search
 ```
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "wildcard": {

--- a/Term Level Queries/working-with-relative-dates.md
+++ b/Term Level Queries/working-with-relative-dates.md
@@ -3,7 +3,7 @@
 ## Subtracting one year from `2010/01/01`
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -18,7 +18,7 @@ GET /product/_search
 ## Subtracting one year and one day from `2010/01/01`
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -33,7 +33,7 @@ GET /product/_search
 ## Subtracting one year from `2010/01/01` and rounding by month
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -48,7 +48,7 @@ GET /product/_search
 ## Rounding by month _before_ subtracting one year from `2010/01/01`
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -63,7 +63,7 @@ GET /product/_search
 ## Rounding by month _before_ subtracting one year from the current date
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {
@@ -78,7 +78,7 @@ GET /product/_search
 ## Matching documents with a `created` field containing the current date or later
 
 ```
-GET /product/_search
+GET /products/_search
 {
   "query": {
     "range": {


### PR DESCRIPTION
Replacing the index name to keep consistent with previous uses in the course