### PR TITLE
Updated importing-data-with-curl.md for Elasticsearch 8

### DIFF
--- a/Managing Documents/importing-data-with-curl.md
+++ b/Managing Documents/importing-data-with-curl.md
@@ -18,7 +18,7 @@ cd C:\Users\[your_username]\Desktop
 ## Importing data into local cluster
 
 ```
-curl -H "Content-Type:application/x-ndjson" -XPOST http://localhost:9200/products/_bulk --data-binary "@products-bulk.json"
+curl --insecure -u elastic:[elasticsearch_password] -H "Content-Type:application/x-ndjson" -XPOST https://localhost:9200/products/_bulk --data-binary "@products-bulk.json"
 ```
 
 ## Importing data into Elastic Cloud 

--- a/Managing Documents/importing-data-with-curl.md
+++ b/Managing Documents/importing-data-with-curl.md
@@ -18,7 +18,10 @@ cd C:\Users\[your_username]\Desktop
 ## Importing data into local cluster
 
 ```
-curl --insecure -u elastic:[elasticsearch_password] -H "Content-Type:application/x-ndjson" -XPOST https://localhost:9200/products/_bulk --data-binary "@products-bulk.json"
+curl --cacert [path_to_CA_certificate] -u elastic -H "Content-Type:application/x-ndjson" -XPOST https://localhost:9200/products/_bulk --data-binary "@products-bulk.json"
+
+# Skipping the verification of the certificate (only for local development)
+curl --insecure -u elastic -H "Content-Type:application/x-ndjson" -XPOST https://localhost:9200/products/_bulk --data-binary "@products-bulk.json"
 ```
 
 ## Importing data into Elastic Cloud 


### PR DESCRIPTION
How to properly use curl with Elasticsearch 8 is very well explained at the beginning of the course.
However I thought it would help everyone, to have the new syntax already available.