### PR TITLE
Update querying-child-documents-by-parent.md (Lesson 95)

### DIFF
--- a/Joining Queries/querying-child-documents-by-parent.md
+++ b/Joining Queries/querying-child-documents-by-parent.md
@@ -9,8 +9,8 @@ GET /department/_search
     "has_parent": {
       "parent_type": "department",
       "query": {
-        "term": {
-          "name.keyword": "Development"
+        "match": {
+          "name": "Development"
         }
       }
     }
@@ -28,8 +28,8 @@ GET /department/_search
       "parent_type": "department",
       "score": true,
       "query": {
-        "term": {
-          "name.keyword": "Development"
+        "match": {
+          "name": "Development"
         }
       }
     }


### PR DESCRIPTION
There is no keyword mapping for the department index (from lesson 91), so the current queries return an empty set of data when using a term query for searching by keyword

Related discussion: https://www.udemy.com/course/elasticsearch-complete-guide/learn/lecture/10131954#questions/11329158